### PR TITLE
Check blocked words against alphabet case-insensitively

### DIFF
--- a/src/Sqids.jl
+++ b/src/Sqids.jl
@@ -42,9 +42,10 @@ struct Configuration{S}
 		# 1. all blocklist words should be lowercase
 		# 2. no words less than 3 chars
 		# 3. if some words contain chars that are not in the alphabet, remove those
-        filteredBlocklist = Set(filter(blocklist) do word
-            length(word) ≥ 3 && issetequal(word ∩ alphabet, word)
-        end .|> lowercase)
+        alphabet_chars = Set(lowercase(alphabet))
+        filteredBlocklist = Set(filter(blocklist .|> lowercase) do word
+            length(word) ≥ 3 && issetequal(word ∩ alphabet_chars, word)
+        end)
         new{strict}(_shuffle(alphabet), minLength, filteredBlocklist)
     end
 end

--- a/test/blocklist.jl
+++ b/test/blocklist.jl
@@ -52,6 +52,16 @@ using Test
         @test Sqids.decode(config, Sqids.encode(config, [1000])) == [1000]
     end
 
+    @testset "blocklist filtering in constructor" begin
+        config = Sqids.configure(alphabet="ABCDEFGHIJKLMNOPQRSTUVWXYZ", blocklist=["sqnmpn"])
+
+        id = Sqids.encode(config, [1, 2, 3])
+        numbers = Sqids.decode(config, id)
+
+        @test id == "ULPBZGBM"  # without blocklist, would've been "SQNMPN"
+        @test numbers == [1, 2, 3]
+    end
+
 end
 
 end  # module BlocklistTests


### PR DESCRIPTION
ref: [Bug: Check blocked words against alphabet case-insensitively · Issue #6 · sqids/sqids-julia](https://github.com/sqids/sqids-julia/issues/6)